### PR TITLE
Add UI visibility toggle settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,12 @@ set(CMAKE_AUTOMOC ON)
 
 # ソースファイル
 set(SOURCES
-    main.cpp
-    MainWindow.cpp
+    src/main.cpp
+    src/MainWindow.cpp
 )
 
 set(HEADERS
-    MainWindow.h
+    src/MainWindow.h
 )
 
 # 実行可能ファイルを作成

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -29,6 +29,10 @@
 #include <QKeyEvent>
 #include <QTimer>
 #include <QPaintEvent>
+#include <QPaintEvent>
+#include <QToolBar>        // 新しく追加
+#include <QGroupBox>       // 新しく追加
+#include <QWidget>         // 新しく追加
 
 class FindReplaceDialog;
 
@@ -97,6 +101,9 @@ private slots:
     void updateStatusBar();
     void documentModified();
     void onWrapWidthChanged(int value);
+    void toggleToolBar();
+    void toggleStatusBarExtras();
+    void showPreferences();
 
 private:
     void setupMenus();
@@ -133,6 +140,19 @@ private:
     QAction *findReplaceAction;
     
     FindReplaceDialog *findDialog;
+        // 新しく追加するメンバー
+    QAction *toggleToolBarAction;
+    QAction *toggleStatusExtrasAction;
+    QAction *preferencesAction;
+    
+    // 設定用メンバー
+    bool toolBarVisible;
+    bool statusExtrasVisible;
+    
+    // UI要素の参照
+    QToolBar *mainToolBar;
+    QWidget *statusExtrasWidget;
+    
 };
 
 // 検索・置換ダイアログ


### PR DESCRIPTION
Features:
- Toggle toolbar visibility via View menu
- Toggle status bar details (font/wrap settings)
- Preferences dialog for UI settings
- Settings persistence across app restarts
- Keyboard shortcuts maintained for WordStar compatibility

UI Changes:
- View menu: Tool Bar, Status Bar Details, Preferences options
- Real-time visibility toggling
- Clean separation of core vs optional UI elements